### PR TITLE
Added a flag (-r) for adding source files in sub-directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Shortened Usage:
 Flags:
     -h    Show this help message
     -y    Accept all files
+    -r    Recursively add source files within subdirs
     -o    Overwrite project if already exists
 
 Examples:

--- a/main.py
+++ b/main.py
@@ -4,7 +4,7 @@ import os
 import sys
 import uuid
 import solution
-from typing import List, NoReturn, Optional, Tuple, TextIO, Union
+from typing import Iterable, List, NoReturn, Optional, Tuple, TextIO, Union
 from shutil import copyfile
 from utils import ask_yes_no_question, bcolors
 from pathlib import Path
@@ -70,9 +70,11 @@ FLAG_LEN = 1
 ACCEPT_ALL_FLAG = 'y'
 HELP_FLAG = 'h'
 OVERWRITE_FLAG = 'o'
+RECURSE_SUBDIRS_FLAG = 'r'
 
 MAIN_PY = 'main.py'
-USAGE_MESSAGE = f"usage: python {MAIN_PY} <source_dir> [(<dest_dir> <solution_name>)] [-h -y -o]"
+USAGE_MESSAGE = f"usage: python {
+    MAIN_PY} <source_dir> [(<dest_dir> <solution_name>)] [-h -y -o]"
 
 BASIC_USAGE_MESSAGE = "Basic Usage:\n    python %s <source_dir> <output_dir> <solution_name>"
 SHORT_USAGE_MESSAGE = "Shortened Usage:\n    python %s <source_dir>"
@@ -88,6 +90,7 @@ HELP_MESSAGE = f'''
 Flags:
     -h    Show this help message
     -y    Accept all files
+    -r    Recursively add source files within subdirs
     -o    Overwrite project if already exists
 
 Examples:
@@ -95,27 +98,58 @@ Examples:
         python main.py DataStructures
 '''
 
-def get_filenames(path: Union[str, os.PathLike]) -> List[str]:
+
+def get_filepaths(base_path: Union[str, os.PathLike], flags) -> List[str]:
     """Returns a list of supported filenames in the given directory."""
-    filenames = []
-    for filename in os.listdir(path):
-        if any(filename.endswith(extension) for extension in SOURCE_EXTENSIONS + HEADER_EXTENSIONS + RESOURCE_EXTENSIONS):
-            filenames.append(filename)
-    return filenames
+    def is_src_file(extension): return extension in SOURCE_EXTENSIONS + \
+        HEADER_EXTENSIONS + RESOURCE_EXTENSIONS
+
+    def strip_start(_path: str): return _path.removeprefix(
+        str(base_path)).removeprefix('/')
+    filepaths = []
+
+    def add_files_in_dir(path: Union[str, os.PathLike], recursive: bool):
+        """Adds all source file paths to local filepaths"""
+        for filename in os.listdir(path):
+            full_path = os.path.join(path, filename)
+
+            if os.path.isdir(full_path) and recursive:
+                dir = strip_start(full_path)
+
+                if ACCEPT_ALL_FLAG in flags or \
+                        ask_yes_no_question(f"Include subdir {bcolors.BOLD}{bcolors.OKCYAN}{dir}{bcolors.ENDC}{bcolors.ENDC} in the build?", default_answer=True):
+                    add_files_in_dir(os.path.join(path, filename), recursive)
+                continue
+
+            extension = Path(full_path).suffix.removeprefix('.')
+            if os.path.isfile(full_path) and is_src_file(extension):
+                filepaths.append(strip_start(full_path))
+
+    add_files_in_dir(base_path, RECURSE_SUBDIRS_FLAG in flags)
+    return filepaths
 
 
 def remove_extension(filename: str) -> str:
     """Removes the source file extension (.c, .cpp, ...) from the filename."""
     return os.path.splitext(filename)[0]
 
+
 def to_items(files: List[str], item_type: str) -> str:
     """Converts a list of files, into `item_type` items for .vcxproj"""
-    convert = lambda file: f'<{item_type} Include="{file}" />'
+    def convert(file): return f'<{item_type} Include="{file}" />'
     return "\n".join(map(convert, files))
+
+
+def to_include_dirs(include_dirs: Iterable[str]) -> str:
+    """Converts a list of include directories into AdditionalIncludeDirectories tag in .vcxproj"""
+    print(include_dirs)
+    return "<AdditionalIncludeDirectories>" + ';'.join(f'$(SolutionDir){dir}' for dir in include_dirs if dir != "") + "</AdditionalIncludeDirectories>"
+
 
 def to_compile_items(files: List[str]) -> str:
     """Converts a list of files, into ClCompile items for .vcxproj"""
     return to_items(files, "ClCompile")
+
 
 def to_include_items(files: List[str]) -> str:
     """Converts a list of files, into ClInclude items for .vcxproj"""
@@ -128,7 +162,7 @@ def to_filter_items(
     """Converts a list of sources, headers and resources into ClCompile and ClInclude with filter for .vcxproj.filter"""
 
     if resources:
-      raise NotImplementedError("Resources are not yet supported")
+        raise NotImplementedError("Resources are not yet supported")
 
     convert = (
         lambda file, filter_type, include_type: f"""<{include_type} Include="{file}">
@@ -136,7 +170,7 @@ def to_filter_items(
     </{include_type}>"""
     )
 
-    convert_files = lambda files, filter_type, include_type: "\n".join(
+    def convert_files(files, filter_type, include_type): return "\n".join(
         convert(file, filter_type, include_type) for file in files
     )
 
@@ -145,7 +179,7 @@ def to_filter_items(
         for files, filter_type, include_type in [
             (sources, "Source Files", "ClCompile"),
             (headers, "Header Files", "ClInclude"),
-            (resources, "Resource Files", ""), # Not implemented
+            (resources, "Resource Files", ""),  # Not implemented
         ]
     )
 
@@ -155,7 +189,7 @@ def split_filenames_by_their_type(
 ) -> Tuple[List[str], List[str], List[str]]:
     """Splits filenames by their extension into a tuple of (sources, headers, resources)"""
 
-    check_type = lambda extensions, filename: any(
+    def check_type(extensions, filename): return any(
         filename.endswith(extension) for extension in extensions
     )
 
@@ -201,20 +235,25 @@ def get_solution(solution_path: Union[str, os.PathLike], always_overwrite: bool)
 
 def main(source_dir: Path, output_dir: Path, solution_name: str, flags: list):
     # Get a list of .c files in the source directory
-    filenames = get_filenames(source_dir)
+    filepaths = get_filepaths(source_dir, flags)
     print(
-        f"Found {bcolors.BOLD}{bcolors.OKCYAN}{len(filenames)}{bcolors.ENDC}{bcolors.ENDC} files in {bcolors.BOLD}{bcolors.OKCYAN}{source_dir}{bcolors.ENDC}{bcolors.ENDC}."
+        f"Found {bcolors.BOLD}{bcolors.OKCYAN}{len(filepaths)}{bcolors.ENDC}{bcolors.ENDC} files in {
+            bcolors.BOLD}{bcolors.OKCYAN}{source_dir}{bcolors.ENDC}{bcolors.ENDC}."
     )
 
     # Select files
     # Accept All flag or Ask the user which files to include in the build
-    selected_filenames = []
-    for filename in filenames:
+    selected_filepaths = []
+    for filepath in filepaths:
         if (ACCEPT_ALL_FLAG in flags or
-                ask_yes_no_question(f"Include {bcolors.BOLD}{bcolors.OKCYAN}{filename}{bcolors.ENDC}{bcolors.ENDC} in the build?", default_answer=True)):
-            selected_filenames.append(filename)
+                ask_yes_no_question(f"Include {bcolors.BOLD}{bcolors.OKCYAN}{filepath}{bcolors.ENDC}{bcolors.ENDC} in the build?", default_answer=True)):
+            selected_filepaths.append(filepath)
 
-    print(f"Selected {bcolors.BOLD}{bcolors.OKCYAN}{len(selected_filenames)}{bcolors.ENDC}{bcolors.ENDC} files for the build.")
+    print(f"Selected {bcolors.BOLD}{bcolors.OKCYAN}{len(selected_filepaths)}{
+          bcolors.ENDC}{bcolors.ENDC} files for the build.")
+
+    include_dirs = set(os.path.dirname(fp) for fp in selected_filepaths if (
+        fp.endswith('.h') or fp.endswith('.hpp')))
 
     solution_path = output_dir / f"{solution_name}.sln"
 
@@ -225,22 +264,27 @@ def main(source_dir: Path, output_dir: Path, solution_name: str, flags: list):
     project_name = solution_name
 
     if not output_dir.exists():
-        output_dir.mkdir(parents=True) # create the directory if it doesn't exists (same for parent directories)
-        print(f"Created output directory {bcolors.BOLD}{bcolors.OKCYAN}{output_dir}{bcolors.ENDC}{bcolors.ENDC}.")
+        # create the directory if it doesn't exists (same for parent directories)
+        output_dir.mkdir(parents=True)
+        print(f"Created output directory {bcolors.BOLD}{
+              bcolors.OKCYAN}{output_dir}{bcolors.ENDC}{bcolors.ENDC}.")
 
     solution_path.write_text(sln_str)
-    print(f"Wrote solution file to {bcolors.BOLD}{bcolors.OKCYAN}{solution_path}{bcolors.ENDC}{bcolors.ENDC}.")
+    print(f"Wrote solution file to {bcolors.BOLD}{bcolors.OKCYAN}{
+          solution_path}{bcolors.ENDC}{bcolors.ENDC}.")
 
     project_vcxproj_path = output_dir / (project_name + VCXPROJ_EXT)
 
-    project_vcxproj_filter_path = output_dir / (project_name + VCXPROJ_FILTER_EXT)
+    project_vcxproj_filter_path = output_dir / \
+        (project_name + VCXPROJ_FILTER_EXT)
 
     if not source_dir.samefile(output_dir):
-        for filename in selected_filenames:
-            copyfile(source_dir / filename, output_dir / filename)
+        for filepath in selected_filepaths:
+            os.makedirs(os.path.dirname(output_dir / filepath), exist_ok=True)
+            copyfile(source_dir / filepath, output_dir / filepath)
 
     sources, headers, resources = split_filenames_by_their_type(
-        selected_filenames
+        selected_filepaths
     )
 
     project_vcxproj_filter_path.write_text(
@@ -253,11 +297,13 @@ def main(source_dir: Path, output_dir: Path, solution_name: str, flags: list):
         VCXPROJ_TEMPLATE_PATH.read_text()
         .replace("$GUID", str(project_guid))
         .replace("$NAME", project_name)
+        .replace("$INCLUDE_DIRS", to_include_dirs(include_dirs))
         .replace("$COMPILE_ITEMS", to_compile_items(sources))
         .replace("$INCLUDE_ITEMS", to_include_items(headers))
     )
 
     print(f"{bcolors.OKGREEN}Done!{bcolors.ENDC}")
+
 
 def help(
     *,
@@ -284,7 +330,8 @@ def usage(
 
 if __name__ == "__main__":
     # Get flags
-    flags = [i for i in sys.argv if FLAG_PREFIX in i and len(i) == len(FLAG_PREFIX) + FLAG_LEN]
+    flags = [i for i in sys.argv if FLAG_PREFIX in i and len(
+        i) == len(FLAG_PREFIX) + FLAG_LEN]
 
     # Remove flags from argv
     argv = list(filter(lambda i: i not in flags, sys.argv))

--- a/templates/template.vcxproj
+++ b/templates/template.vcxproj
@@ -28,26 +28,26 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/templates/template.vcxproj
+++ b/templates/template.vcxproj
@@ -87,6 +87,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      $INCLUDE_DIRS
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -99,6 +100,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      $INCLUDE_DIRS
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -113,6 +115,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      $INCLUDE_DIRS
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -129,6 +132,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      $INCLUDE_DIRS
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>


### PR DESCRIPTION
## Example usage of the -r flag

lets say you have
```
├── include
│   ├── bar.h
│   └── fizzbuzz.h
└── src
    ├── bar.cpp
    └── fizzbuzz.cpp
└── main.cpp
```

you can use the `-r` flag to be prompted about adding files within include and src as-well
the code will also add the include folder (any folder containing a header file) as an additional include directory to allow for things like
```c
#include "bar.h"
```
instead of having to use
```c
#include "include/bar.h"
```

### more patches:

changed the `PlatformToolset` property from v142 -> v143 to switch to the build tools of Visual Studio 2022 (now the required Visual Studio version by magshimim)
```
warning  : The build tools for Visual Studio 2019 (v142) cannot be found. To build using the Visual Studio 2022 (v143) build tools, either click the Project menu or right-click the solution, and then select "Retarget Solution". Install Visual Studio 2019 (v142) to build using the Visual Studio 2019 (v142) build tools.
```


### _small note:_

I had an auto-formatter on while editing `main.py`, it replaced all lambdas of the form
```python3
X = lambda Y: ...
```
to
```python3
def X(Y): return ...
```